### PR TITLE
Fix: update window controls and theme context for improved flexibility

### DIFF
--- a/src/components/TitleBar.tsx
+++ b/src/components/TitleBar.tsx
@@ -16,15 +16,16 @@ export default function Titlebar() {
   return (
     <div
       className={clsx(
-        "w-full h-8 flex items-center justify-between px-3 cursor-default",
+        "w-full h-8 flex items-center justify-between cursor-default",
         appBg,
-        textColor
+        textColor,
+        currentPlatform !== 'windows' ? 'px-3' : null
       )}
       data-tauri-drag-region
     >
-      {currentPlatform === 'macos' && <MacOsControls appBackground={appBg} textTheme={textColor}  />}
-      {currentPlatform === 'windows' && <WindowsControls appBackground={appBg} textTheme={textColor}  />}
-      {currentPlatform === 'linux' && <LinuxControls appBackground={appBg} textTheme={textColor}  />}
+      {currentPlatform === 'macos' && <MacOsControls textTheme={textColor}  />}
+      {currentPlatform === 'windows' && <WindowsControls textTheme={textColor}  />}
+      {currentPlatform === 'linux' && <LinuxControls textTheme={textColor}  />}
     </div>
   );
 }

--- a/src/components/WindowControl/Windows.tsx
+++ b/src/components/WindowControl/Windows.tsx
@@ -47,14 +47,14 @@ export default function WindowsControls({textTheme}: WindowControlsTypes) {
             <div />
             <div className={clsx("text-sm font-medium", textTheme)}>Solo</div>
             <section className="h-full grid grid-cols-3 items-center">
-                <button onClick={minimizeWindow} className="h-full flex items-center justify-center bg-transparent text-white px-4  hover:bg-neutral-500/10">
-                    <Minus size={12} className="stroke-white" />
+                <button onClick={minimizeWindow} className="h-full flex items-center justify-center bg-transparent px-4 hover:bg-neutral-500/10">
+                    <Minus size={12}  />
                 </button>
-                <button onClick={maximizeWindow} className="h-full flex items-center justify-center bg-transparent text-white px-4  hover:bg-neutral-500/10">
-                    {isMaximized ? <SquaresSubtract size={12} className="stroke-white"  /> : <Square size={12} className="stroke-white" />}
+                <button onClick={maximizeWindow} className="h-full flex items-center justify-center bg-transparent px-4 hover:bg-neutral-500/10">
+                    {isMaximized ? <SquaresSubtract size={12}   /> : <Square size={12}  />}
                 </button>
-                <button onClick={closeWindow} className="h-full flex items-center justify-center bg-transparent text-white px-4 hover:bg-red-600">
-                    <X size={16} className="stroke-white" />
+                <button onClick={closeWindow} className="h-full flex items-center justify-center bg-transparent px-4 hover:bg-red-600">
+                    <X size={16}  />
                 </button>
             </section>
         </>

--- a/src/context/ThemeContext.tsx
+++ b/src/context/ThemeContext.tsx
@@ -1,6 +1,6 @@
 import { createContext, useContext, useEffect, useState } from "react";
 
-type Theme = "light" | "dark";
+export type Theme = "light" | "dark";
 
 type ThemeContextType = {
   theme: Theme;

--- a/src/types/WindowControlTypes.ts
+++ b/src/types/WindowControlTypes.ts
@@ -1,1 +1,1 @@
-type WindowControlsTypes = {appBackground: string, textTheme: string}
+type WindowControlsTypes = {appBackground?: string, textTheme: string}


### PR DESCRIPTION
**Description of changes**

**Window control components:**
- Removed the appBackground prop from MacOsControls, WindowsControls, and LinuxControls, as it was unused internally.
- Adjusted the horizontal padding logic (px-3), now conditionally applied based on platform (currentPlatform !== 'windows'), avoiding redundancy.

**Button styling (Windows):**
- Removed the text-white class from icons (Minus, Square, X), keeping color control via stroke or inherited styles.
- No changes were made to hover behavior (hover:bg-*).

**Typing and context:**
- Made the appBackground prop optional in the WindowControlsTypes type.
- Exported the Theme type from ThemeContext.tsx for external reuse.

