### PR TITLE
fix: register graphql_bearer_auth_request + schema version + debounced auto-save

### DIFF
--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -20,6 +20,7 @@ fn main() {
             http::bearer_auth_request,
             http::graphql_request,
             http::graphql_basic_auth_request,
+            http::graphql_bearer_auth_request,
             http::graphql_introspection,
             http::graphql_introspection_with_auth,
             grpc::commands::grpc_unary_request,

--- a/src/context/FileContext.tsx
+++ b/src/context/FileContext.tsx
@@ -1,4 +1,4 @@
-import { createContext, type ReactNode, useContext, useEffect, useState } from "react";
+import { createContext, type ReactNode, useContext, useEffect, useRef, useState } from "react";
 import { useToast } from "../hooks/useToast";
 import { type QueryParam, type RequestType, useRequest } from "./RequestContext";
 import { useVariables } from "./VariablesContext";
@@ -67,6 +67,15 @@ type FileContextType = {
 
 const FileContext = createContext<FileContextType | undefined>(undefined);
 
+const SOLO_SCHEMA_VERSION_KEY = "solo-schema-version";
+const SOLO_SCHEMA_VERSION = "1";
+const AUTO_SAVE_DEBOUNCE_MS = 400;
+
+const isReservedKey = (key: string): boolean =>
+  key.startsWith("solo-variables-") ||
+  key === "solo-environments" ||
+  key === SOLO_SCHEMA_VERSION_KEY;
+
 export const FileProvider = ({ children }: { children: ReactNode }) => {
   const {
     method,
@@ -119,16 +128,54 @@ export const FileProvider = ({ children }: { children: ReactNode }) => {
   const [currentFolder, setCurrentFolder] = useState<string>("");
   const [currentRequestId, setCurrentRequestId] = useState<string | null>(null);
 
+  const saveTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const pendingSaveRef = useRef<(() => void) | null>(null);
+
+  const flushPendingSave = () => {
+    if (saveTimerRef.current) {
+      clearTimeout(saveTimerRef.current);
+      saveTimerRef.current = null;
+    }
+    if (pendingSaveRef.current) {
+      pendingSaveRef.current();
+      pendingSaveRef.current = null;
+    }
+  };
+
   useEffect(() => {
+    if (localStorage.getItem(SOLO_SCHEMA_VERSION_KEY) === null) {
+      localStorage.setItem(SOLO_SCHEMA_VERSION_KEY, SOLO_SCHEMA_VERSION);
+    }
     loadAllFolders();
     document.addEventListener("click", handleClickOutside);
-    return () => document.removeEventListener("click", handleClickOutside);
+    window.addEventListener("beforeunload", flushPendingSave);
+    return () => {
+      document.removeEventListener("click", handleClickOutside);
+      window.removeEventListener("beforeunload", flushPendingSave);
+      flushPendingSave();
+    };
   }, []);
 
   useEffect(() => {
-    if (currentRequestId && currentFolder) {
-      saveCurrentRequest();
+    if (!currentRequestId || !currentFolder) return;
+
+    pendingSaveRef.current = saveCurrentRequest;
+    if (saveTimerRef.current) {
+      clearTimeout(saveTimerRef.current);
     }
+    saveTimerRef.current = setTimeout(() => {
+      saveTimerRef.current = null;
+      const save = pendingSaveRef.current;
+      pendingSaveRef.current = null;
+      save?.();
+    }, AUTO_SAVE_DEBOUNCE_MS);
+
+    return () => {
+      if (saveTimerRef.current) {
+        clearTimeout(saveTimerRef.current);
+        saveTimerRef.current = null;
+      }
+    };
   }, [
     method,
     url,
@@ -158,8 +205,7 @@ export const FileProvider = ({ children }: { children: ReactNode }) => {
     const loadedFolders: FolderStructure = {};
     for (let i = 0; i < localStorage.length; i++) {
       const key = localStorage.key(i);
-      // Exclude solo-variables and solo-environments from folders
-      if (key && !key.startsWith("solo-variables-") && key !== "solo-environments") {
+      if (key && !isReservedKey(key)) {
         try {
           const files = JSON.parse(localStorage.getItem(key) || "[]") as StoredFile[];
           loadedFolders[key] = files.map((file) => file.fileName);
@@ -483,7 +529,7 @@ export const FileProvider = ({ children }: { children: ReactNode }) => {
   ): { folder: string; data: RequestData; displayName?: string } | null => {
     for (let i = 0; i < localStorage.length; i++) {
       const folderName = localStorage.key(i);
-      if (folderName && !folderName.startsWith("solo-variables-")) {
+      if (folderName && !isReservedKey(folderName)) {
         try {
           const files = JSON.parse(localStorage.getItem(folderName) || "[]") as StoredFile[];
           const file = files.find((f) => f.fileName === fileName);


### PR DESCRIPTION
## Summary
- Register `graphql_bearer_auth_request` in `main.rs` invoke_handler — command existed in `http/mod.rs:106` and was invoked from `RequestContext.tsx:197`, but missing from the handler list, breaking any GraphQL request with Bearer auth at runtime.
- Initialize `solo-schema-version=1` baseline in localStorage on first load, and exclude it from folder scans alongside `solo-variables-*` / `solo-environments`. Foundation for future storage migrations (Epic 2).
- Debounce `FileContext` auto-save to 400ms via `useRef`+`setTimeout`, with flush on unmount and `beforeunload`. Removes per-keystroke localStorage writes; prerequisite for Epic 2.

## Test plan
- [x] `cargo check` in `src-tauri/` passes
- [x] `bun run test` — no new failures vs main (24 pre-existing styling-test failures unrelated to storage logic)
- [ ] Manual: GraphQL request with Bearer token executes without "command not found"
- [ ] Manual: rapid edits to payload write to localStorage at most every ~400ms
- [ ] Manual: `localStorage.getItem('solo-schema-version') === "1"` after first run