### PR TITLE
ci: harden CI — frontend job (biome+tsc+build) and expand rust matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,11 +8,31 @@ on:
   workflow_dispatch:
 
 jobs:
+  frontend:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Biome
+        run: bunx biome ci .
+
+      - name: TypeScript typecheck
+        run: bunx tsc --project tsconfig.build.json --noEmit
+
+      - name: Build frontend
+        run: bun run build
+
   test-rust:
     strategy:
       fail-fast: false
       matrix:
-        platform: [macos-latest]
+        platform: [macos-latest, ubuntu-22.04, windows-latest]
 
     runs-on: ${{ matrix.platform }}
     steps:


### PR DESCRIPTION
## Summary
- Adds `frontend` job: `biome ci`, `tsc --project tsconfig.build.json --noEmit`, `bun run build`. Closes audit gaps C2, C3 (no typecheck/lint in CI).
- Expands `test-rust` matrix from `[macos-latest]` to `[macos-latest, ubuntu-22.04, windows-latest]` with `fail-fast: false`. Closes audit gap C4 (no Linux/Windows verification before release).
- Conservative scope: deliberately does NOT add `bun run test` (24 pre-existing styling-test failures need fixing first) or `cargo clippy -D warnings` (6 existing violations).

## Follow-ups
- Fix the 24 styling-related frontend test failures, then add `bun run test` to CI
- Fix clippy violations (`large_enum_variant` in import types, etc.), then add `cargo clippy -D warnings`
- Decide Bun vs npm and remove the unused lockfile (audit C7)
- Repair `manual-release.yml` calling nonexistent `release.yml` (audit C6)
- Add Dependabot config (audit C11)

## Test plan
- [x] Local `bunx biome ci .` passes
- [x] Local `bunx tsc --project tsconfig.build.json --noEmit` passes
- [x] Local `bun run build` produces `dist/`
- [ ] CI — frontend job green
- [ ] CI — test-rust passes on macos-latest (current behavior)
- [ ] CI — test-rust passes on ubuntu-22.04 (new — may surface platform-specific issues)
- [ ] CI — test-rust passes on windows-latest (new — may surface platform-specific issues)